### PR TITLE
Update and rename reusable-workflows/terraform-gcp.yml to .github/wor…

### DIFF
--- a/.github/workflows/reusable-terraform-gcp.yml
+++ b/.github/workflows/reusable-terraform-gcp.yml
@@ -1,4 +1,4 @@
-name: gcp
+name: terraform-gcp
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
…kflows/reusable-terraform-gcp.yml

# Why

> You reference reusable workflow files using one of the following syntaxes:

> {owner}/{repo}/.github/workflows/{filename}@{ref} for reusable workflows in public and private repositories.
> ./.github/workflows/{filename} for reusable workflows in the same repository.

https://docs.github.com/en/actions/sharing-automations/reusing-workflows#calling-a-reusable-workflow