### PR TITLE
feat(setup-poetry): enable to specify python version

### DIFF
--- a/setup-poetry/action.yml
+++ b/setup-poetry/action.yml
@@ -22,7 +22,7 @@ runs:
   steps:
     - id: setup-python
       name: Set up Python
-      uses: actions/setup-python@v5 # version is determined by .python-version
+      uses: actions/setup-python@v5
       with:
         python-version-file: ${{ inputs.python-version-file }}
         python-version: ${{ inputs.python-version }}

--- a/setup-poetry/action.yml
+++ b/setup-poetry/action.yml
@@ -1,7 +1,15 @@
 inputs:
   version:
-    description: 'The version of poetry to install'
+    description: The version of poetry to install
     required: false
+  python-version-file:
+    description: Python version file passed to setup-python (e.g. .python-version, pyproject.toml
+    required: false
+    default: ''
+  python-version:
+    description: Python version passed to setup-python
+    required: false
+    default: ''
   install-dependencies:
     description: boolean whether to run 'poetry install'
     required: false
@@ -15,6 +23,9 @@ runs:
     - id: setup-python
       name: Set up Python
       uses: actions/setup-python@v5 # version is determined by .python-version
+      with:
+        python-version-file: ${{ inputs.python-version-file }}
+        python-version: ${{ inputs.python-version }}
 
     - name: get poetry version from .tool-versions
       id: get-poetry-version


### PR DESCRIPTION
# why

it'd be better to be able to specify python version in the same way as setup-python

# what

add `python-version` and `python-version-file` to inputs