### PR TITLE
docs: update README for LLM PR Reviewer setup

### DIFF
--- a/llm-pr-reviewer/README.md
+++ b/llm-pr-reviewer/README.md
@@ -1,5 +1,8 @@
 # LLM PR Reviewer
 
+> [!NOTE]
+> This GitHub Actions is still alpha version.
+
 A GitHub Action that automatically reviews Pull Requests and adds helpful code improvement suggestions as comments using an LLM (Large Language Model).
 
 ## Features

--- a/pr-description-writer/README.md
+++ b/pr-description-writer/README.md
@@ -2,6 +2,12 @@
 
 A GitHub Action that automatically generates Pull Request titles and descriptions based on code changes.
 
+## Motivation
+
+[pr-agent](https://github.com/qodo-ai/pr-agent) only provides [marker-template](https://qodo-merge-docs.qodo.ai/tools/describe/?h=marker#markers-template)([pr-agent#273](https://github.com/qodo-ai/pr-agent/pull/273)) and doesn't support [pull request template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository) ([pr-agent#213](https://github.com/qodo-ai/pr-agent/issues/213)).
+
+With this GitHub Actions, you can configure how to generate pr title and description more flexibly.
+
 ## Features
 
 - Analyzes changed files in a PR to understand the code changes


### PR DESCRIPTION
# Why

- To provide clear instructions for setting up the LLM PR Reviewer GitHub Action.
- To enhance documentation for better user understanding and adoption.

# What

- Updated the README.md file with detailed setup instructions.
- Included configuration options for LLM providers (OpenAI and Anthropic).
- Added examples for creating workflow files and adding required secrets.