### PR TITLE
feat(pr-description-writer): only update description

### DIFF
--- a/pr-description-writer/README.md
+++ b/pr-description-writer/README.md
@@ -1,12 +1,12 @@
 # PR Description Writer
 
-A GitHub Action that automatically generates Pull Request titles and descriptions based on code changes.
+A GitHub Action that automatically generates Pull Request descriptions based on code changes.
 
 ## Motivation
 
 [pr-agent](https://github.com/qodo-ai/pr-agent) only provides [marker-template](https://qodo-merge-docs.qodo.ai/tools/describe/?h=marker#markers-template)([pr-agent#273](https://github.com/qodo-ai/pr-agent/pull/273)) and doesn't support [pull request template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository) ([pr-agent#213](https://github.com/qodo-ai/pr-agent/issues/213)).
 
-With this GitHub Actions, you can configure how to generate pr title and description more flexibly.
+With this GitHub Actions, you can configure how to generate PR descriptions more flexibly.
 
 ## Features
 
@@ -15,6 +15,7 @@ With this GitHub Actions, you can configure how to generate pr title and descrip
 - Supports custom PR templates
 - Can learn from example PRs to match your team's style
 - Allows custom prompt instructions
+- Update PR description
 
 ## Usage
 
@@ -85,18 +86,9 @@ Please follow these guidelines when generating the PR description:
 Here's an example of a custom prompt file in Japanese for conventional commit style PRs:
 
 ```
-以下の指示に従ってPull Requestのタイトルと説明を生成してください：
+以下の指示に従ってPull Requestの説明を生成してください：
 
-1. title:
-    - format は conventional commit `<type>[optional scope]: <description>`
-        - type: fix, feat, build, chore, ci, docs, style, refactor, perf, test
-    - 簡潔で明確なタイトルを付けてください（50文字以内が理想）
-    - 言語は英語
-    - 最初は小文字
-    - タイプの例: fix, feat, refactor, docs, test, chore など
-    - plain text and no style
-
-2. description:
+1. description:
     - 基本はWhatとWhyのセクション (## What と ## Why)を簡潔にわかりやすく
     - WhatもWhyもともにリスト形式
     - What

--- a/pr-description-writer/action.yml
+++ b/pr-description-writer/action.yml
@@ -1,5 +1,5 @@
 name: "PR Description Writer"
-description: "Automatically generate PR title and description based on code changes"
+description: "Automatically generate PR description based on code changes"
 author: "Your Name"
 
 inputs:

--- a/pr-description-writer/dist/index.js
+++ b/pr-description-writer/dist/index.js
@@ -11,18 +11,16 @@ const path = __nccwpck_require__(6928);
 const axios = __nccwpck_require__(7269);
 
 // Function to calculate similarity between existing and new PR content using LLM
-async function calculateLLMSimilarity(existingTitle, existingBody, newTitle, newBody, llmProvider, apiKey, model) {
+async function calculateLLMSimilarity(existingBody, newBody, llmProvider, apiKey, model) {
     const prompt = `
-Please compare the following two PR titles and descriptions and rate their similarity on a scale from 0.0 to 1.0.
+Please compare the following two PR descriptions and rate their similarity on a scale from 0.0 to 1.0.
 0.0 means completely different, 1.0 means identical in meaning.
 Focus on semantic similarity rather than just word overlap. If they convey the same core changes and purpose, they should have a high similarity score.
 
 PR #1 (Current):
-Title: ${existingTitle || 'N/A'}
 Description: ${existingBody || 'N/A'}
 
 PR #2 (Generated):
-Title: ${newTitle || 'N/A'}
 Description: ${newBody || 'N/A'}
 
 Please provide only a numeric similarity score between 0.0 and 1.0 in your response, with no explanation or additional text.
@@ -273,7 +271,7 @@ async function run() {
         // Build prompt for the LLM
         const prompt = buildPrompt(fileChanges, prTemplate, customPrompt, prExamples);
 
-        // Generate the PR title and description
+        // Generate the PR description
         let result;
         try {
             if (llmProvider === 'openai') {
@@ -284,18 +282,14 @@ async function run() {
                 throw new Error(`Unsupported LLM provider: ${llmProvider}`);
             }
 
-            const newTitle = result.title;
             const newBody = result.description;
 
             // Always log the newly generated content
-            core.info(`Generated PR title: "${newTitle}"`);
             core.info(`Generated PR description length: ${newBody.length} characters`);
 
             // Calculate similarity between current and new content
             const similarityScore = await calculateLLMSimilarity(
-                currentTitle,
                 currentBody,
-                newTitle,
                 newBody,
                 llmProvider,
                 llmProvider === 'openai' ? openaiApiKey : anthropicApiKey,
@@ -306,16 +300,15 @@ async function run() {
             if (similarityScore < similarityThreshold) {
                 core.info(`Similarity score ${similarityScore} is below threshold ${similarityThreshold}. Updating PR...`);
 
-                // Update the PR with the generated title and description
+                // Update only the PR description, not the title
                 await octokit.rest.pulls.update({
                     owner,
                     repo,
                     pull_number: prNumber,
-                    title: newTitle,
                     body: newBody
                 });
 
-                core.info('Successfully updated PR title and description');
+                core.info('Successfully updated PR description only');
             } else {
                 core.info(`Similarity score ${similarityScore} is above threshold ${similarityThreshold}. Not updating PR.`);
             }
@@ -329,7 +322,7 @@ async function run() {
 }
 
 function buildPrompt(fileChanges, prTemplate, customPrompt, prExamples) {
-    let prompt = `You are a GitHub PR description writer. Your task is to generate a title and description for a pull request based on the code changes.
+    let prompt = `You are a GitHub PR description writer. Your task is to generate a description for a pull request based on the code changes.
 
 CODE CHANGES:
 ${JSON.stringify(fileChanges, null, 2)}
@@ -360,14 +353,11 @@ ${customPrompt}
     }
 
     prompt += `
-Please generate a concise, informative PR title and description that summarizes the changes and their purpose.
-The title should be clear and descriptive.
+Please generate a concise, informative PR description that summarizes the changes and their purpose.
 The description should explain the purpose of the changes and any relevant details.
 If a PR template is provided, use it to structure your description.
 
 Your response should be in the following format:
-TITLE: [generated title]
-
 DESCRIPTION:
 [generated description]`;
 
@@ -382,7 +372,7 @@ async function callOpenAI(prompt, apiKey, model) {
                 model: model,
                 messages: [{
                     role: 'user',
-                    content: prompt + "\n\nReturn your response as a JSON object with 'title' and 'description' fields. Do not include any other text."
+                    content: prompt + "\n\nReturn your response as a JSON object with a 'description' field. Do not include any other text."
                 }],
                 response_format: { type: "json_object" },
                 temperature: 0.7,
@@ -401,20 +391,17 @@ async function callOpenAI(prompt, apiKey, model) {
         try {
             const parsed = JSON.parse(content);
             return {
-                title: parsed.title || 'Automated PR Description',
                 description: parsed.description || parsed.body || ''
             };
         } catch (error) {
             core.warning(`Failed to parse OpenAI response as JSON: ${error.message}`);
             return {
-                title: 'Automated PR Description',
                 description: 'The PR description could not be generated correctly. The API did not return valid JSON.'
             };
         }
     } catch (error) {
         core.error(`OpenAI API error: ${error.message}`);
         return {
-            title: 'Automated PR Description',
             description: `The PR description could not be generated due to an API error: ${error.message}`
         };
     }
@@ -428,10 +415,10 @@ async function callAnthropic(prompt, apiKey, model) {
                 model: model,
                 messages: [{
                     role: 'user',
-                    content: prompt + "\n\nReturn your response as a JSON object with 'title' and 'description' fields. The JSON object should be valid and parseable. Do not include any other text outside of the JSON object."
+                    content: prompt + "\n\nReturn your response as a JSON object with a 'description' field. The JSON object should be valid and parseable. Do not include any other text outside of the JSON object."
                 }],
                 max_tokens: 2000,
-                system: "Return your response as a valid, parseable JSON object with 'title' and 'description' fields. Include only the JSON object in your response, with no additional explanations or text."
+                system: "Return your response as a valid, parseable JSON object with a 'description' field. Include only the JSON object in your response, with no additional explanations or text."
             },
             {
                 headers: {
@@ -450,20 +437,17 @@ async function callAnthropic(prompt, apiKey, model) {
             const jsonStr = jsonMatch ? jsonMatch[0] : content;
             const parsed = JSON.parse(jsonStr);
             return {
-                title: parsed.title || 'Automated PR Description',
                 description: parsed.description || parsed.body || ''
             };
         } catch (error) {
             core.warning(`Failed to parse Anthropic response as JSON: ${error.message}`);
             return {
-                title: 'Automated PR Description',
                 description: 'The PR description could not be generated correctly. The API did not return valid JSON.'
             };
         }
     } catch (error) {
         core.error(`Anthropic API error: ${error.message}`);
         return {
-            title: 'Automated PR Description',
             description: `The PR description could not be generated due to an API error: ${error.message}`
         };
     }

--- a/pr-description-writer/pr_prompt.txt
+++ b/pr-description-writer/pr_prompt.txt
@@ -1,15 +1,6 @@
-以下の指示に従ってPull Requestのタイトルと説明を生成してください：
+以下の指示に従ってPull Requestの説明を生成してください：
 
-1. title:
-    - format は conventional commit `<type>[optional scope]: <description>`
-        - type: fix, feat, build, chore, ci, docs, style, refactor, perf, test
-    - 簡潔で明確なタイトルを付けてください（50文字以内が理想）
-    - 言語は英語
-    - 最初は小文字
-    - タイプの例: fix, feat, refactor, docs, test, chore など
-    - plain text and no style
-
-2. description:
+description:
     - 基本はWhatとWhyのセクション (## What と ## Why)を簡潔にわかりやすく
     - WhatもWhyもともにリスト形式
     - What

--- a/pr-description-writer/similarity.test.js
+++ b/pr-description-writer/similarity.test.js
@@ -33,9 +33,7 @@ describe('calculateLLMSimilarity (actual implementation)', () => {
         });
 
         const similarity = await calculateLLMSimilarity(
-            'Fix login bug',
             'This PR fixes the login bug',
-            'Fix authentication issue',
             'This PR fixes an auth problem',
             'openai',
             'fake_api_key',
@@ -75,9 +73,7 @@ describe('calculateLLMSimilarity (actual implementation)', () => {
         });
 
         const similarity = await calculateLLMSimilarity(
-            'Fix login bug',
             'This PR fixes the login bug',
-            'Fix authentication issue',
             'This PR fixes an auth problem',
             'anthropic',
             'fake_api_key',
@@ -110,9 +106,7 @@ describe('calculateLLMSimilarity (actual implementation)', () => {
         axios.post.mockRejectedValueOnce(new Error('API error'));
 
         const similarity = await calculateLLMSimilarity(
-            'Fix login bug',
             'This PR fixes the login bug',
-            'Fix authentication issue',
             'This PR fixes an auth problem',
             'openai',
             'fake_api_key',
@@ -129,9 +123,7 @@ describe('calculateLLMSimilarity (actual implementation)', () => {
         axios.post.mockRejectedValueOnce(new Error('API error'));
 
         const similarity = await calculateLLMSimilarity(
-            'Fix login bug',
             'This PR fixes the login bug',
-            'Fix authentication issue',
             'This PR fixes an auth problem',
             'anthropic',
             'fake_api_key',
@@ -158,9 +150,7 @@ describe('calculateLLMSimilarity (actual implementation)', () => {
         });
 
         const similarity = await calculateLLMSimilarity(
-            'Fix login bug',
             'This PR fixes the login bug',
-            'Fix authentication issue',
             'This PR fixes an auth problem',
             'openai',
             'fake_api_key',
@@ -184,9 +174,7 @@ describe('calculateLLMSimilarity (actual implementation)', () => {
         });
 
         const similarity = await calculateLLMSimilarity(
-            'Fix login bug',
             'This PR fixes the login bug',
-            'Fix authentication issue',
             'This PR fixes an auth problem',
             'anthropic',
             'fake_api_key',
@@ -199,9 +187,7 @@ describe('calculateLLMSimilarity (actual implementation)', () => {
 
     test('handles unsupported LLM provider', async () => {
         const similarity = await calculateLLMSimilarity(
-            'Fix login bug',
             'This PR fixes the login bug',
-            'Fix authentication issue',
             'This PR fixes an auth problem',
             'unknown_provider',
             'fake_api_key',
@@ -228,9 +214,7 @@ describe('calculateLLMSimilarity (actual implementation)', () => {
         });
 
         let similarity = await calculateLLMSimilarity(
-            'Fix login bug',
             'This PR fixes the login bug',
-            'Fix authentication issue',
             'This PR fixes an auth problem',
             'openai',
             'fake_api_key',
@@ -254,9 +238,7 @@ describe('calculateLLMSimilarity (actual implementation)', () => {
         });
 
         similarity = await calculateLLMSimilarity(
-            'Fix login bug',
             'This PR fixes the login bug',
-            'Fix authentication issue',
             'This PR fixes an auth problem',
             'openai',
             'fake_api_key',


### PR DESCRIPTION
# What

- Added a GitHub Action for automatically generating Pull Request descriptions based on code changes.
- Enhanced functionality to allow the use of OpenAI and Anthropic LLMs for generating meaningful PR descriptions.
- Introduced support for custom PR templates and custom prompt instructions.

# Why

- The existing [pr-agent](https://github.com/qodo-ai/pr-agent) only supports marker templates and lacks the ability to use pull request templates.
- This new action provides more flexibility in generating PR descriptions, making it easier to communicate changes effectively within teams.