### PR TITLE
chore: fix set-image-tag

### DIFF
--- a/set-image-tag/action.yml
+++ b/set-image-tag/action.yml
@@ -16,7 +16,7 @@ runs:
         if [[ "${{ github.event_name }}" = 'pull_request' ]]; then
           echo "IMAGE_TAG=pr-${{ github.event.number }}" >> "$GITHUB_OUTPUT"
         elif [ "${{ github.event_name }}" == 'release' ]; then
-          echo "IMAGE_TAG=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          echo "IMAGE_TAG=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
         elif [ "${{ github.event_name }}" == 'push' ]; then
           echo "IMAGE_TAG=${{ github.ref_name }}-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
         else


### PR DESCRIPTION
# why

ref_name is empty for release

# what

set explicitly release tag name with `github.event.release.tag_name`

# ref

https://github.com/actions/runner/issues/2788