### PR TITLE
chore: update reusable-terraform-gcp.yml

### DIFF
--- a/.github/workflows/reusable-terraform-aws.yml
+++ b/.github/workflows/reusable-terraform-aws.yml
@@ -34,9 +34,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: install aqua
-        uses: aquaproj/aqua-installer@v3.0.1
+        uses: aquaproj/aqua-installer@v4.0.0
         with:
-          aqua_version: v2.29.0
+          aqua_version: v2.51.2
 
       - name: install tfcmt
         run: aqua i

--- a/.github/workflows/reusable-terraform-gcp.yml
+++ b/.github/workflows/reusable-terraform-gcp.yml
@@ -34,9 +34,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: install aqua
-        uses: aquaproj/aqua-installer@v3.0.1
+        uses: aquaproj/aqua-installer@v4.0.0
         with:
-          aqua_version: v2.29.0
+          aqua_version: v2.51.2
 
       - name: install tfcmt via aqua
         run: |


### PR DESCRIPTION
# Why

- To ensure the workflow uses the latest version of the Aqua installer and Aqua version for better features and security.

# What

- Updated the Aqua installer action from version `v3.0.1` to `v4.0.0`.
- Updated the Aqua version from `v2.29.0` to `v2.51.2`.