### PR TITLE
feat: create reusable-terraform-github.yml

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -103,3 +103,35 @@ jobs:
       region: ap-northeast-1
       identifier: aws-naka
 ```
+
+### GitHub
+
+```yaml
+name: github
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  terraform:
+    uses: nakamasato/github-actions/.github/workflows/reusable-terraform-github.yml@main
+    with:
+      working_directory: <dir>
+      project: <project name>
+      workload_identity_provider: projects/<project id>/locations/global/workloadIdentityPools/<pool>/providers/<provider>
+      service_account: <sa name>@<project name>.iam.gserviceaccount.com
+    secrets:
+      gh_app_id: ${{ secrets.GH_APP_ID }}
+      gh_private_key: ${{ secrets.GH_PRIVATE_KEY }}
+```

--- a/.github/workflows/reusable-terraform-github.yml
+++ b/.github/workflows/reusable-terraform-github.yml
@@ -35,7 +35,6 @@ jobs:
       contents: read
       id-token: write
       pull-requests: write
-      security-events: read
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -98,13 +97,11 @@ jobs:
       - name: Terraform Plan
         if: github.event_name != 'push' || github.ref_name != 'main'
         env:
-          GH_TOKEN: ${{ steps.github-app-token.outputs.token }}
-        run: |
-          gh api repos/nakamasato/fastapi-sample/vulnerability-alerts --include
-          #tfcmt -var "target:${{ inputs.project }}" plan -patch -- terraform plan -no-color
+          GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token }}
+        run: tfcmt -var "target:${{ inputs.project }}" plan -patch -- terraform plan -no-color
 
       - name: Terraform Apply
         if: github.event_name == 'push' && github.ref_name == 'main'
         env:
-          GH_TOKEN: ${{ steps.github-app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token }}
         run: tfcmt -var "target:${{ inputs.project }}" apply -- terraform apply -no-color -auto-approve -input=false

--- a/.github/workflows/reusable-terraform-github.yml
+++ b/.github/workflows/reusable-terraform-github.yml
@@ -99,7 +99,9 @@ jobs:
         if: github.event_name != 'push' || github.ref_name != 'main'
         env:
           GH_TOKEN: ${{ steps.github-app-token.outputs.token }}
-        run: tfcmt -var "target:${{ inputs.project }}" plan -patch -- terraform plan -no-color
+        run: |
+          gh api repos/nakamasato/fastapi-sample/vulnerability-alerts --include
+          #tfcmt -var "target:${{ inputs.project }}" plan -patch -- terraform plan -no-color
 
       - name: Terraform Apply
         if: github.event_name == 'push' && github.ref_name == 'main'

--- a/.github/workflows/reusable-terraform-github.yml
+++ b/.github/workflows/reusable-terraform-github.yml
@@ -1,0 +1,107 @@
+name: terraform-github
+on:
+  workflow_call:
+    inputs:
+      working_directory:
+        type: string
+        required: false
+        default: "."
+      project:
+        type: string
+        required: false
+        default: "default"
+      # GCP config: currently only support GCS backend
+      workload_identity_provider:
+        type: string
+        required: false
+      service_account:
+        type: string
+        required: false
+    secrets:
+      # GitHub App
+      gh_app_id:
+        required: true
+      gh_private_key:
+        required: true
+
+concurrency:
+  group: terraform-github-${{ inputs.project }}
+  cancel-in-progress: false
+
+jobs:
+  terraform:
+    permissions:
+      issues: write # allow to create repo label
+      contents: read
+      id-token: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ inputs.working_directory }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate GitHub App Token
+        id: github-app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.gh_app_id }}
+          private-key: ${{ secrets.gh_private_key }}
+          owner: ${{ github.repository_owner }}
+
+      - name: install aqua
+        uses: aquaproj/aqua-installer@v4.0.0
+        with:
+          aqua_version: v2.51.2
+
+      - name: install tfcmt via aqua
+        run: |
+          if [ -f aqua.yaml ];then
+            aqua i
+          else
+            aqua g -i suzuki-shunsuke/tfcmt
+          fi
+
+      # For GCS bucket backend
+      - id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: google-github-actions/auth@v2
+        with:
+          create_credentials_file: 'true'
+          workload_identity_provider: ${{ inputs.workload_identity_provider }}
+          service_account: ${{ inputs.service_account }}
+
+      - name: set-tf-version
+        id: set-tf-version
+        working-directory: .
+        run: |
+          echo "terraform_version=$(cat .terraform-version)" >> $GITHUB_OUTPUT
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ steps.set-tf-version.outputs.terraform_version }}
+
+      - name: Terraform fmt
+        id: fmt
+        run: terraform fmt -check -recursive
+
+      - name: Terraform Init
+        id: init
+        run: terraform init
+
+      - name: Terraform Validate
+        id: validate
+        run: terraform validate -no-color
+
+      - name: Terraform Plan
+        if: github.event_name != 'push' || github.ref_name != 'main'
+        env:
+          GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token }}
+        run: tfcmt -var "target:${{ inputs.project }}" plan -patch -- terraform plan -no-color
+
+      - name: Terraform Apply
+        if: github.event_name == 'push' && github.ref_name == 'main'
+        env:
+          GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token }}
+        run: tfcmt -var "target:${{ inputs.project }}" apply -- terraform apply -no-color -auto-approve -input=false

--- a/.github/workflows/reusable-terraform-github.yml
+++ b/.github/workflows/reusable-terraform-github.yml
@@ -97,11 +97,11 @@ jobs:
       - name: Terraform Plan
         if: github.event_name != 'push' || github.ref_name != 'main'
         env:
-          GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.github-app-token.outputs.token }}
         run: tfcmt -var "target:${{ inputs.project }}" plan -patch -- terraform plan -no-color
 
       - name: Terraform Apply
         if: github.event_name == 'push' && github.ref_name == 'main'
         env:
-          GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.github-app-token.outputs.token }}
         run: tfcmt -var "target:${{ inputs.project }}" apply -- terraform apply -no-color -auto-approve -input=false

--- a/.github/workflows/reusable-terraform-github.yml
+++ b/.github/workflows/reusable-terraform-github.yml
@@ -35,6 +35,7 @@ jobs:
       contents: read
       id-token: write
       pull-requests: write
+      security-events: read
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 1. [reusable-terraform-aws](https://github.com/nakamasato/github-actions/blob/main/.github/workflows/reusable-terraform-aws.yml)
 1. [reusable-terraform-gcp](https://github.com/nakamasato/github-actions/blob/main/.github/workflows/reusable-terraform-gcp.yml)
+1. [reusable-terraform-github](https://github.com/nakamasato/github-actions/blob/main/.github/workflows/reusable-terraform-github.yml)
 
 ## [Composite Actions](https://docs.github.com/en/actions/sharing-automations/creating-actions/creating-a-composite-action)
 


### PR DESCRIPTION
# ✨ What

- Added a new GitHub Actions workflow for managing Terraform deployments.
- Supports input parameters for working directory, project name, GCP workload identity provider, and service account.
- Includes steps for GitHub App token generation, Google Cloud authentication, and Terraform commands (format, init, validate, plan, apply).

# 🛠️ Why

- To streamline Terraform operations within GitHub Actions, enabling easier integration and deployment of infrastructure as code.