### PR TITLE
Update reusable-terraform-github.yml

### DIFF
--- a/.github/workflows/reusable-terraform-github.yml
+++ b/.github/workflows/reusable-terraform-github.yml
@@ -97,7 +97,9 @@ jobs:
       - name: Terraform Plan
         if: github.event_name != 'push' || github.ref_name != 'main'
         env:
-          GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token }}
+          # https://github.com/suzuki-shunsuke/tfcmt/blob/6cb66ca833829e713563b928f0b99f1401dd6677/pkg/notifier/github/client.go#L71-L79
+          TFCMT_GITHUB_TOKEN: ${{ secrets.github_token }} # For tfcmt (permissions are set above)
+          GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token }} # For github provider (permissions are set for the GitHub app)
         run: tfcmt -var "target:${{ inputs.project }}" plan -patch -- terraform plan -no-color
 
       - name: Terraform Apply


### PR DESCRIPTION
# Why

- To enhance the Terraform workflow by ensuring proper token usage for GitHub operations.

# What

- Modified the GitHub Actions workflow to include a new environment variable `TFCMT_GITHUB_TOKEN` for `tfcmt` with the appropriate permissions.
- Maintained the existing `GITHUB_TOKEN` for the GitHub provider, ensuring compatibility with the GitHub app.
- Added a comment with a reference link for clarification on the token usage.