### PR TITLE
chore: fix the logic to set terraform version

### DIFF
--- a/.github/workflows/llm-pr-reviewer.yml
+++ b/.github/workflows/llm-pr-reviewer.yml
@@ -5,19 +5,19 @@ on:
     branches: [ main ]
 
 jobs:
-  review:
-    permissions:
-      contents: read
-      pull-requests: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: llm-pr-reviewer
-        uses: ./llm-pr-reviewer
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          openai_api_key: ${{ secrets.OPENAI_API_KEY }}
-          # debug: true
+  # review:
+  #   permissions:
+  #     contents: read
+  #     pull-requests: write
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: llm-pr-reviewer
+  #       uses: ./llm-pr-reviewer
+  #       with:
+  #         github_token: ${{ secrets.GITHUB_TOKEN }}
+  #         openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+  #         # debug: true
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-terraform-aws.yml
+++ b/.github/workflows/reusable-terraform-aws.yml
@@ -15,9 +15,13 @@ on:
       identifier:
         type: string
         required: true
+      terraform_version_file:
+        type: string
+        required: false
+        default: ".terraform-version" # use 'latest' if not exists
 
 concurrency:
-  group: ${{ inputs.identifier }}
+  group: ${{ github.workflow }}-${{ inputs.identifier }}
   cancel-in-progress: false
 
 jobs:
@@ -51,7 +55,13 @@ jobs:
       - name: set-tf-version
         id: set-tf-version
         run: |
-          echo "terraform_version=$(cat .terraform-version)" >> $GITHUB_OUTPUT
+          version_file="${{ inputs.terraform_version_file }}"
+          if [ -f "$version_file" ]; then
+            version=$(cat "$version_file")
+          else
+            version="latest"
+          fi
+          echo "terraform_version=$version" >> $GITHUB_OUTPUT
 
       - uses: hashicorp/setup-terraform@v3
         with:

--- a/.github/workflows/reusable-terraform-aws.yml
+++ b/.github/workflows/reusable-terraform-aws.yml
@@ -54,6 +54,7 @@ jobs:
 
       - name: set-tf-version
         id: set-tf-version
+        working-directory: .
         run: |
           version_file="${{ inputs.terraform_version_file }}"
           if [ -f "$version_file" ]; then

--- a/.github/workflows/reusable-terraform-gcp.yml
+++ b/.github/workflows/reusable-terraform-gcp.yml
@@ -61,6 +61,7 @@ jobs:
 
       - name: set-tf-version
         id: set-tf-version
+        working-directory: .
         run: |
           version_file="${{ inputs.terraform_version_file }}"
           if [ -f "$version_file" ]; then

--- a/.github/workflows/reusable-terraform-gcp.yml
+++ b/.github/workflows/reusable-terraform-gcp.yml
@@ -9,6 +9,10 @@ on:
       project:
         type: string
         required: true
+      terraform_version_file:
+        type: string
+        required: false
+        default: ".terraform-version" # use 'latest' if not exists
       workload_identity_provider:
         type: string
         required: true
@@ -17,7 +21,7 @@ on:
         required: true
 
 concurrency:
-  group: ${{ inputs.project }}
+  group: ${{ github.workflow }}-${{ inputs.project }}
   cancel-in-progress: false
 
 jobs:
@@ -58,7 +62,13 @@ jobs:
       - name: set-tf-version
         id: set-tf-version
         run: |
-          echo "terraform_version=$(cat .terraform-version)" >> $GITHUB_OUTPUT
+          version_file="${{ inputs.terraform_version_file }}"
+          if [ -f "$version_file" ]; then
+            version=$(cat "$version_file")
+          else
+            version="latest"
+          fi
+          echo "terraform_version=$version" >> $GITHUB_OUTPUT
 
       - uses: hashicorp/setup-terraform@v3
         with:

--- a/.github/workflows/reusable-terraform-github.yml
+++ b/.github/workflows/reusable-terraform-github.yml
@@ -17,6 +17,10 @@ on:
       service_account:
         type: string
         required: false
+      terraform_version_file:
+        type: string
+        required: false
+        default: ".terraform-version" # use 'latest' if not exists
     secrets:
       # GitHub App
       gh_app_id:
@@ -76,7 +80,13 @@ jobs:
         id: set-tf-version
         working-directory: .
         run: |
-          echo "terraform_version=$(cat .terraform-version)" >> $GITHUB_OUTPUT
+          version_file="${{ inputs.terraform_version_file }}"
+          if [ -f "$version_file" ]; then
+            version=$(cat "$version_file")
+          else
+            version="latest"
+          fi
+          echo "terraform_version=$version" >> $GITHUB_OUTPUT
 
       - uses: hashicorp/setup-terraform@v3
         with:


### PR DESCRIPTION
# Why

- To provide flexibility in specifying the Terraform version file when using the reusable Terraform GCP workflow.
- To improve the handling of the Terraform version by allowing a default value of 'latest' if the specified file does not exist.

# What

- Added a new input `terraform_version_file` that allows users to specify the path to the Terraform version file (defaulting to `.terraform-version`).
- Updated the logic in the workflow to read the Terraform version from the specified file or fall back to 'latest' if the file is not found.
- Modified the concurrency group naming to include the workflow name for better identification.