### PR TITLE
chore: fix 'configuration file isn't found' in case aqua.yaml doesn't…

### DIFF
--- a/.github/workflows/reusable-terraform-gcp.yml
+++ b/.github/workflows/reusable-terraform-gcp.yml
@@ -48,6 +48,7 @@ jobs:
           if [ -f aqua.yaml ];then
             aqua i
           else
+            aqua init
             aqua g -i suzuki-shunsuke/tfcmt
           fi
 


### PR DESCRIPTION
# Why

- Ensure that Aqua is initialized correctly before running other commands.

# What

- Added `aqua init` command to the workflow to initialize Aqua if the `aqua.yaml` file does not exist.