### PR TITLE
chore: fix install tfcmt from aqua

### DIFF
--- a/.github/workflows/reusable-terraform-aws.yml
+++ b/.github/workflows/reusable-terraform-aws.yml
@@ -43,8 +43,13 @@ jobs:
         with:
           aqua_version: v2.51.2
 
-      - name: install tfcmt
-        run: aqua i
+      - name: install tfcmt via aqua
+        run: |
+          if [ -f aqua.yaml ];then
+            aqua i
+          else
+            aqua i suzuki-shunsuke/tfcmt
+          fi
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4.2.1

--- a/.github/workflows/reusable-terraform-aws.yml
+++ b/.github/workflows/reusable-terraform-aws.yml
@@ -45,11 +45,11 @@ jobs:
 
       - name: install tfcmt via aqua
         run: |
-          if [ -f aqua.yaml ];then
-            aqua i
-          else
-            aqua i suzuki-shunsuke/tfcmt
+          if [ ! -f aqua.yaml ];then
+            aqua init
+            aqua g -i suzuki-shunsuke/tfcmt
           fi
+          aqua i
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4.2.1

--- a/.github/workflows/reusable-terraform-gcp.yml
+++ b/.github/workflows/reusable-terraform-gcp.yml
@@ -48,8 +48,7 @@ jobs:
           if [ -f aqua.yaml ];then
             aqua i
           else
-            aqua init
-            aqua g -i suzuki-shunsuke/tfcmt
+            aqua i suzuki-shunsuke/tfcmt
           fi
 
       - id: 'auth'

--- a/.github/workflows/reusable-terraform-gcp.yml
+++ b/.github/workflows/reusable-terraform-gcp.yml
@@ -45,11 +45,11 @@ jobs:
 
       - name: install tfcmt via aqua
         run: |
-          if [ -f aqua.yaml ];then
-            aqua i
-          else
-            aqua i suzuki-shunsuke/tfcmt
+          if [ ! -f aqua.yaml ];then
+            aqua init
+            aqua g -i suzuki-shunsuke/tfcmt
           fi
+          aqua i
 
       - id: 'auth'
         name: 'Authenticate to Google Cloud'

--- a/.github/workflows/reusable-terraform-github.yml
+++ b/.github/workflows/reusable-terraform-github.yml
@@ -64,7 +64,7 @@ jobs:
           if [ -f aqua.yaml ];then
             aqua i
           else
-            aqua g -i suzuki-shunsuke/tfcmt
+            aqua i suzuki-shunsuke/tfcmt
           fi
 
       # For GCS bucket backend

--- a/.github/workflows/reusable-terraform-github.yml
+++ b/.github/workflows/reusable-terraform-github.yml
@@ -61,11 +61,11 @@ jobs:
 
       - name: install tfcmt via aqua
         run: |
-          if [ -f aqua.yaml ];then
-            aqua i
-          else
-            aqua i suzuki-shunsuke/tfcmt
+          if [ ! -f aqua.yaml ];then
+            aqua init
+            aqua g -i suzuki-shunsuke/tfcmt
           fi
+          aqua i
 
       # For GCS bucket backend
       - id: 'auth'


### PR DESCRIPTION
# Why

- To enhance the installation process of `tfcmt` in the GitHub workflows.

# What

- Modified the installation step for `tfcmt` in `.github/workflows/reusable-terraform-aws.yml` to check for the existence of `aqua.yaml`.
- Updated the GCP and GitHub workflow files to streamline the installation of `tfcmt` by removing unnecessary commands.
- Ensured consistency across all workflow files regarding the installation of `tfcmt`.