### PR TITLE
chore: Create pinact.yml

### DIFF
--- a/.github/workflows/llm-pr-reviewer.yml
+++ b/.github/workflows/llm-pr-reviewer.yml
@@ -22,7 +22,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up Poetry
         uses: ./setup-poetry
         with:

--- a/.github/workflows/pinact.yml
+++ b/.github/workflows/pinact.yml
@@ -13,5 +13,5 @@ jobs:
       - name: Pin actions
         uses: suzuki-shunsuke/pinact-action@d735505f3decf76fca3fdbb4c952e5b3eba0ffdd # v0.1.2
         with:
-          app_id: ${{secrets.GH_APP_ID}}
-          app_private_key: ${{secrets.GH_PRIVATE_KEY}}
+          app_id: ${{secrets.GH_APP_APP_ID}}
+          app_private_key: ${{secrets.GH_APP_PRIVATE_KEY}}

--- a/.github/workflows/pinact.yml
+++ b/.github/workflows/pinact.yml
@@ -1,0 +1,17 @@
+name: pinact
+on:
+  pull_request: {}
+jobs:
+  pinact:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Pin actions
+        uses: suzuki-shunsuke/pinact-action@d735505f3decf76fca3fdbb4c952e5b3eba0ffdd # v0.1.2
+        with:
+          app_id: ${{secrets.GH_APP_ID}}
+          app_private_key: ${{secrets.GH_PRIVATE_KEY}}

--- a/.github/workflows/pr-description-writer-test.yml
+++ b/.github/workflows/pr-description-writer-test.yml
@@ -18,10 +18,10 @@ jobs:
         working-directory: ./pr-description-writer
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/pr-description-writer.yml
+++ b/.github/workflows/pr-description-writer.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,6 +6,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-      - uses: pre-commit/action@v3.0.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/reusable-terraform-aws.yml
+++ b/.github/workflows/reusable-terraform-aws.yml
@@ -36,10 +36,10 @@ jobs:
       run:
         working-directory: ${{ inputs.working_directory }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: install aqua
-        uses: aquaproj/aqua-installer@v4.0.2
+        uses: aquaproj/aqua-installer@d1fe50798dbadd4eb5b98957290ca175f6b4870f # v4.0.2
         with:
           aqua_version: v2.51.2
 
@@ -52,7 +52,7 @@ jobs:
           aqua i
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4.2.1
+        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
         with:
           role-to-assume: ${{ inputs.iam_role }}
           aws-region: ${{ inputs.region }}
@@ -69,7 +69,7 @@ jobs:
           fi
           echo "terraform_version=$version" >> $GITHUB_OUTPUT
 
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_version: ${{ steps.set-tf-version.outputs.terraform_version }}
 

--- a/.github/workflows/reusable-terraform-gcp.yml
+++ b/.github/workflows/reusable-terraform-gcp.yml
@@ -40,7 +40,7 @@ jobs:
       run:
         working-directory: ${{ inputs.working_directory }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         if: inputs.enable_aqua_cache == 'true'
@@ -64,7 +64,7 @@ jobs:
 
       - id: 'auth'
         name: 'Authenticate to Google Cloud'
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f # v2.1.7
         with:
           create_credentials_file: 'true'
           workload_identity_provider: ${{ inputs.workload_identity_provider }}
@@ -82,7 +82,7 @@ jobs:
           fi
           echo "terraform_version=$version" >> $GITHUB_OUTPUT
 
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_version: ${{ steps.set-tf-version.outputs.terraform_version }}
 

--- a/.github/workflows/reusable-terraform-github.yml
+++ b/.github/workflows/reusable-terraform-github.yml
@@ -44,18 +44,18 @@ jobs:
       run:
         working-directory: ${{ inputs.working_directory }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Generate GitHub App Token
         id: github-app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
         with:
           app-id: ${{ secrets.gh_app_id }}
           private-key: ${{ secrets.gh_private_key }}
           owner: ${{ github.repository_owner }}
 
       - name: install aqua
-        uses: aquaproj/aqua-installer@v4.0.2
+        uses: aquaproj/aqua-installer@d1fe50798dbadd4eb5b98957290ca175f6b4870f # v4.0.2
         with:
           aqua_version: v2.51.2
 
@@ -70,7 +70,7 @@ jobs:
       # For GCS bucket backend
       - id: 'auth'
         name: 'Authenticate to Google Cloud'
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f # v2.1.7
         with:
           create_credentials_file: 'true'
           workload_identity_provider: ${{ inputs.workload_identity_provider }}
@@ -88,7 +88,7 @@ jobs:
           fi
           echo "terraform_version=$version" >> $GITHUB_OUTPUT
 
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
           terraform_version: ${{ steps.set-tf-version.outputs.terraform_version }}
 

--- a/build-and-push-to-gar/action.yaml
+++ b/build-and-push-to-gar/action.yaml
@@ -60,29 +60,29 @@ runs:
   steps:
     - name: Authenticate to Google Cloud
       id: auth
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f # v2.1.7
       with:
         token_format: access_token
         workload_identity_provider: ${{ inputs.workload_identity_provider }}
         service_account: ${{ inputs.service_account }}
 
     - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@v2
+      uses: google-github-actions/setup-gcloud@6189d56e4096ee891640bb02ac264be376592d6a # v2.1.2
 
     - name: Login to GAR
-      uses: docker/login-action@v3
+      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
       with:
         registry: ${{ inputs.region }}-docker.pkg.dev
         username: oauth2accesstoken
         password: ${{ steps.auth.outputs.access_token }}
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
       with:
         driver: ${{ inputs.driver }}
 
     - name: Cache Docker layers
-      uses: actions/cache@v4
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: /tmp/.buildx-cache
         key: ${{ runner.os }}-buildx-${{ inputs.service }}-${{ github.sha }}
@@ -91,7 +91,7 @@ runs:
 
     - name: Build and push image
       id: build-push-action
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
       with:
         context: ${{ inputs.context }}
         file: ${{ inputs.dockerfile }}

--- a/deploy-python-app-to-cloud-run/action.yml
+++ b/deploy-python-app-to-cloud-run/action.yml
@@ -59,17 +59,17 @@ runs:
   steps:
     - name: Authenticate to Google Cloud
       id: auth
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f # v2.1.7
       with:
         token_format: access_token
         workload_identity_provider: ${{ inputs.workload_identity_provider }}
         service_account: ${{ inputs.service_account }}
 
     - name: Set up Cloud SDK
-      uses: google-github-actions/setup-gcloud@v2
+      uses: google-github-actions/setup-gcloud@6189d56e4096ee891640bb02ac264be376592d6a # v2.1.2
 
     - name: Login to GAR
-      uses: docker/login-action@v3
+      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
       with:
         registry: ${{ inputs.region }}-docker.pkg.dev
         username: oauth2accesstoken
@@ -77,12 +77,12 @@ runs:
 
     - name: Set up Docker Buildx
       if: inputs.dockerfile != ''
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
       with:
         driver: ${{ inputs.driver }}
 
     - name: Cache Docker layers
-      uses: actions/cache@v4
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       if: inputs.dockerfile != ''
       with:
         path: /tmp/.buildx-cache
@@ -92,7 +92,7 @@ runs:
 
     - name: Build and push image
       if: inputs.dockerfile != ''
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
       with:
         context: ${{ inputs.context }}
         file: ${{ inputs.dockerfile }}
@@ -114,7 +114,7 @@ runs:
     # Buildpack is slow https://github.com/buildpacks/pack
     - name: Install Pack CLI
       if: inputs.dockerfile == ''
-      uses: buildpacks/github-actions/setup-pack@v5.9.2
+      uses: buildpacks/github-actions/setup-pack@bc04fbfd78e903050bab17a2dcf907e71e3c4afa # v5.9.2
 
     - name: Build app with pack CLI using Buildpack Cache image (see https://buildpacks.io/docs/app-developer-guide/using-cache-image/) & publish to Docker Hub
       if: inputs.dockerfile == ''

--- a/llm-pr-reviewer/action.yml
+++ b/llm-pr-reviewer/action.yml
@@ -48,12 +48,12 @@ runs:
   using: 'composite'
   steps:
     - name: Checkout github actions repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         fetch-depth: 0
         repository: nakamasato/github-actions
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: '3.13'
 

--- a/setup-poetry/action.yml
+++ b/setup-poetry/action.yml
@@ -27,7 +27,7 @@ runs:
   steps:
     - id: setup-python
       name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version-file: ${{ inputs.python-version-file }}
         python-version: ${{ inputs.python-version }}
@@ -46,7 +46,7 @@ runs:
 
     - name: Load cached Poetry installation
       id: cached-poetry
-      uses: actions/cache@v4
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: ~/.local  # the path depends on the OS
         key: poetry-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ steps.get-poetry-version.outputs.POETRY_VERSION }}
@@ -56,7 +56,7 @@ runs:
     #----------------------------------------------
     - name: Install Poetry (${{ steps.get-poetry-version.outputs.POETRY_VERSION }})
       if: steps.cached-poetry.outputs.cache-hit != 'true'
-      uses: snok/install-poetry@v1
+      uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
       with:
         version: ${{ steps.get-poetry-version.outputs.POETRY_VERSION }}
         virtualenvs-create: true
@@ -69,7 +69,7 @@ runs:
     #----------------------------------------------
     - name: Load cached venv
       id: cached-poetry-dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: .venv
         key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ steps.get-poetry-version.outputs.POETRY_VERSION }}-${{ hashFiles('**/poetry.lock') }}


### PR DESCRIPTION
# Why

- To enhance the automation of GitHub Actions workflows and ensure consistent usage of action versions.

# What

- Updated multiple workflow files to use specific versions of actions instead of the latest versions:
  - Changed `actions/checkout` to version `11bd71901bbe5b1630ceea73d27597364c9af683` (v4.2.2) across several workflows.
  - Updated `actions/setup-node` to version `49933ea5288caeca8642d1e84afbd3f7d6820020` (v4.4.0).
  - Enhanced the `pinact.yml` workflow to automatically pin action versions on pull requests.