### PR TITLE
chore: Update reusable-terraform-gcp.yml

### DIFF
--- a/.github/workflows/reusable-terraform-gcp.yml
+++ b/.github/workflows/reusable-terraform-gcp.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-        if: inputs.enable_aqua_cache == 'true'
+        if: inputs.enable_aqua_cache
         with:
           path: ~/.local/share/aquaproj-aqua
           key: v2-aqua-installer-${{runner.os}}-${{runner.arch}}-${{hashFiles('aqua.yaml')}}


### PR DESCRIPTION
# Why

- To simplify the conditional check for enabling the Aqua cache in the GitHub Actions workflow.

# What

- Updated the condition to check `inputs.enable_aqua_cache` directly instead of comparing it to the string 'true'.
- This change enhances readability and reduces potential errors in the condition evaluation.