### PR TITLE
chore: add enable_aqua_cache option

### DIFF
--- a/.github/workflows/reusable-terraform-aws.yml
+++ b/.github/workflows/reusable-terraform-aws.yml
@@ -2,6 +2,10 @@ name: terraform-aws
 on:
   workflow_call:
     inputs:
+      enable_aqua_cache:
+        type: boolean
+        required: false
+        default: false
       working_directory:
         type: string
         required: false
@@ -37,6 +41,14 @@ jobs:
         working-directory: ${{ inputs.working_directory }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        if: inputs.enable_aqua_cache
+        with:
+          path: ~/.local/share/aquaproj-aqua
+          key: v2-aqua-installer-${{runner.os}}-${{runner.arch}}-${{hashFiles('aqua.yaml')}}
+          restore-keys: |
+            v2-aqua-installer-${{runner.os}}-${{runner.arch}}-
 
       - name: install aqua
         uses: aquaproj/aqua-installer@d1fe50798dbadd4eb5b98957290ca175f6b4870f # v4.0.2

--- a/.github/workflows/reusable-terraform-github.yml
+++ b/.github/workflows/reusable-terraform-github.yml
@@ -2,6 +2,10 @@ name: terraform-github
 on:
   workflow_call:
     inputs:
+      enable_aqua_cache:
+        type: boolean
+        required: false
+        default: false
       working_directory:
         type: string
         required: false
@@ -53,6 +57,14 @@ jobs:
           app-id: ${{ secrets.gh_app_id }}
           private-key: ${{ secrets.gh_private_key }}
           owner: ${{ github.repository_owner }}
+
+      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        if: inputs.enable_aqua_cache
+        with:
+          path: ~/.local/share/aquaproj-aqua
+          key: v2-aqua-installer-${{runner.os}}-${{runner.arch}}-${{hashFiles('aqua.yaml')}}
+          restore-keys: |
+            v2-aqua-installer-${{runner.os}}-${{runner.arch}}-
 
       - name: install aqua
         uses: aquaproj/aqua-installer@d1fe50798dbadd4eb5b98957290ca175f6b4870f # v4.0.2


### PR DESCRIPTION
# Why

- To enhance the flexibility of the Terraform AWS workflow by allowing the optional use of Aqua caching.

# What

- Added an input parameter `enable_aqua_cache` to the workflow, which is a boolean type and defaults to false.
- Integrated the `actions/cache` step to cache Aqua installer files when `enable_aqua_cache` is true.
- Updated the workflow to conditionally use the cache based on the new input parameter.