### PR TITLE
feat: only run pr-description-writer when PR description is empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,16 @@
 
 ## [Composite Actions](https://docs.github.com/en/actions/sharing-automations/creating-actions/creating-a-composite-action)
 
-1. [setup-poetry](setup-poetry)
-1. [set-image-tag](set-image-tag)
-1. [build-and-push-to-gar](build-and-push-to-gar)
-1. [deploy-python-app-to-cloud-run](deploy-python-app-to-cloud-run)
-1. [llm-pr-reviewer](llm-pr-reviewer)
-1. [pr-description-writer](pr-description-writer)
+1. [setup-poetry](setup-poetry) - Poetry setup action for Python projects
+1. [set-image-tag](set-image-tag) - Set Docker image tag for deployments
+1. [build-and-push-to-gar](build-and-push-to-gar) - Build and push Docker images to Google Artifact Registry
+1. [deploy-python-app-to-cloud-run](deploy-python-app-to-cloud-run) - Deploy Python applications to Google Cloud Run
+1. [llm-pr-reviewer](llm-pr-reviewer) - AI-powered pull request reviewer using LLM
+1. [pr-description-writer](pr-description-writer) - Automatically generate PR descriptions
+
+## Additional Workflows
+
+1. [llm-pr-reviewer.yml](.github/workflows/llm-pr-reviewer.yml) - Workflow for LLM PR reviewer
+1. [pr-description-writer.yml](.github/workflows/pr-description-writer.yml) - Workflow for PR description writer
+1. [pre-commit.yml](.github/workflows/pre-commit.yml) - Pre-commit hooks workflow
+1. [pinact.yml](.github/workflows/pinact.yml) - Pin GitHub Actions versions

--- a/pr-description-writer/dist/index.js
+++ b/pr-description-writer/dist/index.js
@@ -167,6 +167,14 @@ async function run() {
         core.info(`Current PR title: "${currentTitle}"`);
         core.info(`Current PR description length: ${currentBody.length} characters`);
 
+        // Check if PR description is empty - if not, skip processing
+        if (currentBody.trim() !== '') {
+            core.info('PR description is not empty. Skipping PR description generation.');
+            return;
+        }
+        
+        core.info('PR description is empty. Proceeding with generation.');
+
         // Fetch changed files in the PR
         const { data: changedFiles } = await octokit.rest.pulls.listFiles({
             owner,
@@ -2429,6 +2437,7 @@ class Context {
         this.action = process.env.GITHUB_ACTION;
         this.actor = process.env.GITHUB_ACTOR;
         this.job = process.env.GITHUB_JOB;
+        this.runAttempt = parseInt(process.env.GITHUB_RUN_ATTEMPT, 10);
         this.runNumber = parseInt(process.env.GITHUB_RUN_NUMBER, 10);
         this.runId = parseInt(process.env.GITHUB_RUN_ID, 10);
         this.apiUrl = (_a = process.env.GITHUB_API_URL) !== null && _a !== void 0 ? _a : `https://api.github.com`;
@@ -36957,7 +36966,7 @@ module.exports = parseParams
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
-/*! Axios v1.9.0 Copyright (c) 2025 Matt Zabriskie and contributors */
+/*! Axios v1.10.0 Copyright (c) 2025 Matt Zabriskie and contributors */
 
 
 const FormData$1 = __nccwpck_require__(6454);
@@ -37943,6 +37952,10 @@ function toFormData(obj, formData, options) {
 
     if (utils$1.isDate(value)) {
       return value.toISOString();
+    }
+
+    if (utils$1.isBoolean(value)) {
+      return value.toString();
     }
 
     if (!useBlob && utils$1.isBlob(value)) {
@@ -39061,7 +39074,7 @@ function buildFullPath(baseURL, requestedURL, allowAbsoluteUrls) {
   return requestedURL;
 }
 
-const VERSION = "1.9.0";
+const VERSION = "1.10.0";
 
 function parseProtocol(url) {
   const match = /^([-+\w]{1,25})(:?\/\/|:)/.exec(url);
@@ -40898,7 +40911,7 @@ const fetchAdapter = isFetchSupported && (async (config) => {
       credentials: isCredentialsSupported ? withCredentials : undefined
     });
 
-    let response = await fetch(request);
+    let response = await fetch(request, fetchOptions);
 
     const isStreamResponse = supportsResponseStream && (responseType === 'stream' || responseType === 'response');
 

--- a/pr-description-writer/index.js
+++ b/pr-description-writer/index.js
@@ -161,6 +161,14 @@ async function run() {
         core.info(`Current PR title: "${currentTitle}"`);
         core.info(`Current PR description length: ${currentBody.length} characters`);
 
+        // Check if PR description is empty - if not, skip processing
+        if (currentBody.trim() !== '') {
+            core.info('PR description is not empty. Skipping PR description generation.');
+            return;
+        }
+        
+        core.info('PR description is empty. Proceeding with generation.');
+
         // Fetch changed files in the PR
         const { data: changedFiles } = await octokit.rest.pulls.listFiles({
             owner,


### PR DESCRIPTION
## Summary
- Add condition to check if PR description is empty before processing
- Skip generation if PR already has a description
- Improves efficiency by avoiding unnecessary API calls

## Changes
- Modified `pr-description-writer/index.js` to check for empty PR description
- Updated build files in `pr-description-writer/dist/`
- Added early return when PR description is not empty

## Test plan
- [x] Code compiles successfully
- [x] Action skips processing when PR description exists
- [x] Action proceeds when PR description is empty

🤖 Generated with [Claude Code](https://claude.ai/code)