### PR TITLE
chore: update reusable-terraform-gcp.yml

### DIFF
--- a/.github/workflows/reusable-terraform-gcp.yml
+++ b/.github/workflows/reusable-terraform-gcp.yml
@@ -55,6 +55,8 @@ jobs:
           aqua_version: v2.51.2
 
       - name: install tfcmt via aqua
+        env:
+          GITHUB_TOKEN: ${{ secrets.github_token }}
         run: |
           if [ ! -f aqua.yaml ];then
             aqua init


### PR DESCRIPTION
# Why

- This change ensures that the `GITHUB_TOKEN` is available as an environment variable for the Aqua installation step.

# What

- Added `env` section to the Aqua installation step in the workflow.
- Set `GITHUB_TOKEN` to use the repository's secret token.