### PR TITLE
chore: add GITHUB_TOKEN env var to remaining aqua install steps

### DIFF
--- a/.github/workflows/reusable-terraform-aws.yml
+++ b/.github/workflows/reusable-terraform-aws.yml
@@ -56,6 +56,8 @@ jobs:
           aqua_version: v2.51.2
 
       - name: install tfcmt via aqua
+        env:
+          GITHUB_TOKEN: ${{ secrets.github_token }}
         run: |
           if [ ! -f aqua.yaml ];then
             aqua init

--- a/.github/workflows/reusable-terraform-github.yml
+++ b/.github/workflows/reusable-terraform-github.yml
@@ -72,6 +72,8 @@ jobs:
           aqua_version: v2.51.2
 
       - name: install tfcmt via aqua
+        env:
+          GITHUB_TOKEN: ${{ secrets.github_token }}
         run: |
           if [ ! -f aqua.yaml ];then
             aqua init


### PR DESCRIPTION
## Summary
- Add GITHUB_TOKEN environment variable to aqua install steps in reusable-terraform-aws.yml and reusable-terraform-github.yml
- Follows the same pattern established in PR #93 for reusable-terraform-gcp.yml
- Ensures consistent environment variable configuration across all aqua install steps

## Test plan
- [x] Verify changes match the pattern from PR #93
- [x] Confirm all aqua install steps now have consistent GITHUB_TOKEN env var
- [ ] Workflow validation will occur automatically via GitHub Actions

🤖 Generated with [Claude Code](https://claude.ai/code)