### PR TITLE
chore: update readme

### DIFF
--- a/.github/workflows/reusable-terraform-aws.md
+++ b/.github/workflows/reusable-terraform-aws.md
@@ -29,10 +29,14 @@ jobs:
 | `region` | string | **true** | - | AWS region for operations |
 | `identifier` | string | **true** | - | Unique identifier for concurrency control |
 | `terraform_version_file` | string | false | `".terraform-version"` | File containing Terraform version (uses 'latest' if not found) |
+| `save_tfplan` | boolean | false | `false` | Save Terraform plan as artifact |
+| `tfplan_retention_days` | number | false | `1` | Number of days to retain Terraform plan artifact |
 
 ## Outputs
 
-This workflow does not produce outputs.
+| Name | Description |
+|------|-------------|
+| `tfplan_artifact_name` | Name of the artifact containing terraform plan JSON |
 
 ## Prerequisites
 
@@ -74,4 +78,6 @@ jobs:
       region: "us-east-1"
       identifier: "my-project"
       enable_aqua_cache: true
+      save_tfplan: true
+      tfplan_retention_days: 3
 ```

--- a/.github/workflows/reusable-terraform-gcp.md
+++ b/.github/workflows/reusable-terraform-gcp.md
@@ -29,10 +29,14 @@ jobs:
 | `terraform_version_file` | string | false | `".terraform-version"` | File containing Terraform version (uses 'latest' if not found) |
 | `workload_identity_provider` | string | **true** | - | GCP Workload Identity Provider resource name |
 | `service_account` | string | **true** | - | GCP service account email for authentication |
+| `save_tfplan` | boolean | false | `false` | Save Terraform plan as artifact |
+| `tfplan_retention_days` | number | false | `1` | Number of days to retain Terraform plan artifact |
 
 ## Outputs
 
-This workflow does not produce outputs.
+| Name | Description |
+|------|-------------|
+| `tfplan_artifact_name` | Name of the artifact containing terraform plan JSON |
 
 ## Prerequisites
 
@@ -74,4 +78,6 @@ jobs:
       workload_identity_provider: "projects/123456789012/locations/global/workloadIdentityPools/my-pool/providers/my-provider"
       service_account: "terraform@my-gcp-project.iam.gserviceaccount.com"
       enable_aqua_cache: true
+      save_tfplan: true
+      tfplan_retention_days: 3
 ```

--- a/.github/workflows/reusable-terraform-github.md
+++ b/.github/workflows/reusable-terraform-github.md
@@ -32,6 +32,8 @@ jobs:
 | `workload_identity_provider` | string | false | - | GCP Workload Identity Provider (for GCS backend) |
 | `service_account` | string | false | - | GCP service account email (for GCS backend) |
 | `terraform_version_file` | string | false | `".terraform-version"` | File containing Terraform version (uses 'latest' if not found) |
+| `save_tfplan` | boolean | false | `false` | Save Terraform plan as artifact |
+| `tfplan_retention_days` | number | false | `1` | Number of days to retain Terraform plan artifact |
 
 ## Secrets
 
@@ -42,7 +44,9 @@ jobs:
 
 ## Outputs
 
-This workflow does not produce outputs.
+| Name | Description |
+|------|-------------|
+| `tfplan_artifact_name` | Name of the artifact containing terraform plan JSON |
 
 ## Prerequisites
 
@@ -86,6 +90,8 @@ jobs:
       workload_identity_provider: "projects/123456789012/locations/global/workloadIdentityPools/my-pool/providers/my-provider"
       service_account: "terraform@my-gcp-project.iam.gserviceaccount.com"
       enable_aqua_cache: true
+      save_tfplan: true
+      tfplan_retention_days: 3
     secrets:
       gh_app_id: ${{ secrets.GH_APP_ID }}
       gh_private_key: ${{ secrets.GH_PRIVATE_KEY }}


### PR DESCRIPTION
# Why

- To enhance the Terraform workflows for AWS, GCP, and GitHub by adding new features for better artifact management.

# What

- Introduced `save_tfplan` input parameter to control the saving of the Terraform plan as an artifact.
- Added `tfplan_retention_days` input parameter to specify the number of days to retain the Terraform plan artifact.
- Updated the output section to reflect the new artifact name for the Terraform plan JSON.
- Maintained backward compatibility by keeping existing parameters intact.