### PR TITLE
add gitleaks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,9 @@ repos:
         exclude: '\.json$'
       - id: check-yaml
       - id: check-added-large-files
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.27.2
+    hooks:
+      - id: gitleaks
+        name: Detect hardcoded secrets
+        description: Detect hardcoded secrets using Gitleaks


### PR DESCRIPTION
# Why

- To enhance security checks in the codebase by detecting hardcoded secrets.

# What

- Updated the pre-commit configuration to include Gitleaks.
  - Added Gitleaks repository reference.
  - Configured Gitleaks to run as a hook to detect hardcoded secrets.