### PR TITLE
Add action-required-reminder to root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@
 1. [deploy-python-app-to-cloud-run](deploy-python-app-to-cloud-run) - Deploy Python applications to Google Cloud Run
 1. [pr-description-writer](pr-description-writer) - Automatically generate PR descriptions
 1. [monthly-project-summary-slack](monthly-project-summary-slack) - Generate monthly project summaries with Claude Code and post to Slack (supports cross-organization access)
+1. [action-required-reminder](action-required-reminder) - Check for unreplied Slack messages and unreviewed GitHub PRs, then send reminders to Slack


### PR DESCRIPTION
## Summary
- Add action-required-reminder composite action to the root README.md
- Include description of its functionality for checking unreplied Slack messages and unreviewed GitHub PRs

## Details
The action-required-reminder action was recently merged but the root README.md was not updated to include it in the list of available composite actions.

🤖 Generated with [Claude Code](https://claude.ai/code)