### PR TITLE
Fix actionlint violations in Terraform workflows

### DIFF
--- a/.github/workflows/reusable-terraform-aws.yml
+++ b/.github/workflows/reusable-terraform-aws.yml
@@ -95,7 +95,7 @@ jobs:
           else
             version="latest"
           fi
-          echo "terraform_version=$version" >> $GITHUB_OUTPUT
+          echo "terraform_version=$version" >> "$GITHUB_OUTPUT"
 
       - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
@@ -122,7 +122,7 @@ jobs:
           terraform show -json tfplan.binary > tfplan.json
           if [ "${{ inputs.save_tfplan }}" = "true" ]; then
             artifact_name="tfplan-${{ github.workflow }}-${{ inputs.identifier }}-${{ github.run_id }}"
-            echo "tfplan_artifact_name=$artifact_name" >> $GITHUB_OUTPUT
+            echo "tfplan_artifact_name=$artifact_name" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Upload Terraform Plan Artifact

--- a/.github/workflows/reusable-terraform-gcp.yml
+++ b/.github/workflows/reusable-terraform-gcp.yml
@@ -96,7 +96,7 @@ jobs:
           else
             version="latest"
           fi
-          echo "terraform_version=$version" >> $GITHUB_OUTPUT
+          echo "terraform_version=$version" >> "$GITHUB_OUTPUT"
 
       - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
@@ -124,7 +124,7 @@ jobs:
           terraform show -json tfplan.binary > tfplan.json
           if [ "${{ inputs.save_tfplan }}" = "true" ]; then
             artifact_name="tfplan-${{ github.workflow }}-${{ inputs.project }}-${{ github.run_id }}"
-            echo "tfplan_artifact_name=$artifact_name" >> $GITHUB_OUTPUT
+            echo "tfplan_artifact_name=$artifact_name" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Upload Terraform Plan Artifact

--- a/.github/workflows/reusable-terraform-github.yml
+++ b/.github/workflows/reusable-terraform-github.yml
@@ -114,7 +114,7 @@ jobs:
           else
             version="latest"
           fi
-          echo "terraform_version=$version" >> $GITHUB_OUTPUT
+          echo "terraform_version=$version" >> "$GITHUB_OUTPUT"
 
       - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
         with:
@@ -144,7 +144,7 @@ jobs:
           terraform show -json tfplan.binary > tfplan.json
           if [ "${{ inputs.save_tfplan }}" = "true" ]; then
             artifact_name="tfplan-${{ github.workflow }}-${{ inputs.project }}-${{ github.run_id }}"
-            echo "tfplan_artifact_name=$artifact_name" >> $GITHUB_OUTPUT
+            echo "tfplan_artifact_name=$artifact_name" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Upload Terraform Plan Artifact

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,17 @@ repos:
         exclude: '\.json$'
       - id: check-yaml
       - id: check-added-large-files
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.1
+    hooks:
+      - id: actionlint
+        name: Lint GitHub Actions workflow files
+        description: Runs actionlint to lint GitHub Actions workflow files
+        language: golang
+        types: ["yaml"]
+        files: ^\.github/workflows/
+        entry: actionlint
+        minimum_pre_commit_version: 3.0.0
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.27.2
     hooks:


### PR DESCRIPTION
## Summary
- Fix shellcheck violations flagged by actionlint in Terraform reusable workflows
- Quote `$GITHUB_OUTPUT` variables to prevent globbing and word splitting
- Add actionlint to pre-commit hooks for future violation prevention

## Test plan
- [x] Verify actionlint passes without violations
- [x] Pre-commit hooks run successfully

🤖 Generated with [Claude Code](https://claude.ai/code)