### PR TITLE
feat: add exclude_slack_usernames

### DIFF
--- a/action-required-reminder/action.yml
+++ b/action-required-reminder/action.yml
@@ -35,6 +35,9 @@ inputs:
     description: 'GitHub Token for repository access'
     required: false
     default: ${{ github.token }}
+  exclude_slack_usernames:
+    description: 'Slack usernames to exclude from message checks (newline-separated)'
+    required: false
 
 runs:
   using: 'composite'
@@ -54,6 +57,7 @@ runs:
         SLACK_WORKSPACE: ${{ inputs.slack_workspace }}
         SLACK_USER_ID: ${{ inputs.slack_user_id }}
         SLACK_START_DATE: ${{ steps.calc-date.outputs.start_date }}
+        EXCLUDE_SLACK_USERNAMES: ${{ inputs.exclude_slack_usernames }}
       run: |
         # Output logs to stderr and capture only URLs from stdout
         echo "Running Slack message check..."
@@ -98,84 +102,92 @@ runs:
         PR_COUNT: ${{ steps.check-prs.outputs.count }}
         PR_URLS: ${{ steps.check-prs.outputs.urls }}
       run: |
-        # Build header block
-        BLOCKS='[
-          {
+        # Check if no action is required
+        if [ "$SLACK_COUNT" -eq 0 ] && [ "$PR_COUNT" -eq 0 ]; then
+          # Simple one-line message when nothing to do
+          BLOCKS='[
+            {
+              "type": "section",
+              "text": {
+                "type": "mrkdwn",
+                "text": "✅️ Awesome! No action required :tada:"
+              }
+            }
+          ]'
+        else
+          # Build detailed message when action is required
+          BLOCKS='[
+            {
+              "type": "section",
+              "text": {
+                "type": "mrkdwn",
+                "text": "👋 This is action required reminder!"
+              }
+            }
+          ]'
+
+          # Add Slack messages section
+          SLACK_SECTION='{
             "type": "section",
             "text": {
               "type": "mrkdwn",
-              "text": "👋 This is action required reminder!"
+              "text": "📬 *Unreplied Slack messages: '$SLACK_COUNT' messages*"
             }
-          }
-        ]'
+          }'
+          BLOCKS=$(echo "$BLOCKS" | jq ". += [$SLACK_SECTION]")
 
-        # Add Slack messages section
-        SLACK_SECTION='{
-          "type": "section",
-          "text": {
-            "type": "mrkdwn",
-            "text": "📬 *Unreplied Slack messages: '$SLACK_COUNT' messages*"
-          }
-        }'
-        BLOCKS=$(echo "$BLOCKS" | jq ". += [$SLACK_SECTION]")
-
-        # Add Slack links if any exist
-        if [ "$SLACK_COUNT" -gt 0 ]; then
-          # Build Slack links list (filter out empty titles)
-          SLACK_LINKS=$(echo "$SLACK_URLS" | jq -r '.[] | select(.title != "" and .title != null) | "• <" + .url + "|" + (.title | gsub("[<>|]"; "")) + ">"' | tr '\n' '\n')
-          if [ -n "$SLACK_LINKS" ]; then
-            SLACK_LINKS_SECTION='{
-              "type": "section",
-              "text": {
-                "type": "mrkdwn",
-                "text": "'"$SLACK_LINKS"'"
-              }
-            }'
-            BLOCKS=$(echo "$BLOCKS" | jq ". += [$SLACK_LINKS_SECTION]")
+          # Add Slack links if any exist
+          if [ "$SLACK_COUNT" -gt 0 ]; then
+            # Build Slack links list (filter out empty titles)
+            SLACK_LINKS=$(echo "$SLACK_URLS" | jq -r '.[] | select(.title != "" and .title != null) | "• <" + .url + "|" + (.title | gsub("[<>|]"; "")) + ">"' | tr '\n' '\n')
+            if [ -n "$SLACK_LINKS" ]; then
+              SLACK_LINKS_SECTION='{
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "'"$SLACK_LINKS"'"
+                }
+              }'
+              BLOCKS=$(echo "$BLOCKS" | jq ". += [$SLACK_LINKS_SECTION]")
+            fi
           fi
-        fi
 
-        # Add PR section
-        PR_SECTION='{
-          "type": "section",
-          "text": {
-            "type": "mrkdwn",
-            "text": "🔍 *Review Requested PR: '$PR_COUNT' PRs*"
-          }
-        }'
-        BLOCKS=$(echo "$BLOCKS" | jq ". += [$PR_SECTION]")
+          # Add PR section
+          PR_SECTION='{
+            "type": "section",
+            "text": {
+              "type": "mrkdwn",
+              "text": "🔍 *Review Requested PR: '$PR_COUNT' PRs*"
+            }
+          }'
+          BLOCKS=$(echo "$BLOCKS" | jq ". += [$PR_SECTION]")
 
-        # Add PR links if any exist
-        if [ "$PR_COUNT" -gt 0 ]; then
-          # Build PR links list (filter out empty titles)
-          PR_LINKS=$(echo "$PR_URLS" | jq -r '.[] | select(.title != "" and .title != null) | "• <" + .url + "|" + (.title | gsub("[<>|]"; "")) + ">"' | tr '\n' '\n')
-          if [ -n "$PR_LINKS" ]; then
-            PR_LINKS_SECTION='{
-              "type": "section",
-              "text": {
-                "type": "mrkdwn",
-                "text": "'"$PR_LINKS"'"
-              }
-            }'
-            BLOCKS=$(echo "$BLOCKS" | jq ". += [$PR_LINKS_SECTION]")
+          # Add PR links if any exist
+          if [ "$PR_COUNT" -gt 0 ]; then
+            # Build PR links list (filter out empty titles)
+            PR_LINKS=$(echo "$PR_URLS" | jq -r '.[] | select(.title != "" and .title != null) | "• <" + .url + "|" + (.title | gsub("[<>|]"; "")) + ">"' | tr '\n' '\n')
+            if [ -n "$PR_LINKS" ]; then
+              PR_LINKS_SECTION='{
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "'"$PR_LINKS"'"
+                }
+              }'
+              BLOCKS=$(echo "$BLOCKS" | jq ". += [$PR_LINKS_SECTION]")
+            fi
           fi
-        fi
 
-        # Add footer
-        if [ "$SLACK_COUNT" -eq 0 ] && [ "$PR_COUNT" -eq 0 ]; then
-          FOOTER_TEXT="✨ Awesome! No action required! ✅️"
-        else
-          FOOTER_TEXT="Keep it up! 💪"
+          # Add footer
+          FOOTER_SECTION='{
+            "type": "section",
+            "text": {
+              "type": "mrkdwn",
+              "text": "Keep it up! 💪"
+            }
+          }'
+          BLOCKS=$(echo "$BLOCKS" | jq ". += [$FOOTER_SECTION]")
         fi
-
-        FOOTER_SECTION='{
-          "type": "section",
-          "text": {
-            "type": "mrkdwn",
-            "text": "'$FOOTER_TEXT'"
-          }
-        }'
-        BLOCKS=$(echo "$BLOCKS" | jq ". += [$FOOTER_SECTION]")
 
         # Save blocks to output
         echo "blocks<<EOF" >> "$GITHUB_OUTPUT"

--- a/action-required-reminder/check_not_reviewed_gh_pr.sh
+++ b/action-required-reminder/check_not_reviewed_gh_pr.sh
@@ -26,6 +26,7 @@ main() {
         exit 1
     fi
 
+
     # Search PRs and output as JSON
     eval "gh search prs ${search_query} --json url,title --limit 100"
 }


### PR DESCRIPTION
When both Slack messages and GitHub PRs are zero, show only a single line message:
"✅️ Awesome\! No action required :tada:"

This reduces notification noise when there's nothing to act on.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
