### PR TITLE
chore: fix comment of deploy-cloudrun

### DIFF
--- a/deploy-cloudrun/action.yml
+++ b/deploy-cloudrun/action.yml
@@ -197,7 +197,7 @@ runs:
           </details>
 
           ---
-          *Last updated: ${{ github.event.head_commit.timestamp }}*
+          [Run #${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
     - name: Update deployment status (success)
       if: success() && inputs.environment != '' && steps.deployment.outputs.result != ''


### PR DESCRIPTION
# Why

- Improve clarity of deployment information in GitHub Actions.

# What

- Updated the deployment status message to include a direct link to the specific run.
  - Changed from displaying the last updated timestamp to showing a link format: `[Run #${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})`.