### PR TITLE
deploy-cloudrun: remove unnecessary output pr_url

### DIFF
--- a/deploy-cloudrun/README.md
+++ b/deploy-cloudrun/README.md
@@ -178,7 +178,6 @@ This action automatically configures deployments based on context:
 |--------|-------------|
 | `url` | Service URL |
 | `revision` | Deployed revision name |
-| `pr_url` | PR-specific URL (for PR deployments only) |
 
 ## Deployment Behavior
 
@@ -273,7 +272,7 @@ For PR cleanup with commenting support, see the [cleanup-cloudrun-traffic-tag ac
 
 2. **PR URLs Not Working**:
    - PR deployments receive 0% traffic by default
-   - Use the tagged URL from the `pr_url` output
+   - Use the tagged URL from the `url` output
    - Verify the service is deployed successfully
 
 ### Debugging

--- a/deploy-cloudrun/action.yml
+++ b/deploy-cloudrun/action.yml
@@ -94,9 +94,6 @@ outputs:
   revision:
     description: "Deployed revision name"
     value: ${{ steps.deploy.outputs.revision }}
-  pr_url:
-    description: "PR-specific URL (only for PR deployments)"
-    value: ${{ github.event_name == 'pull_request' && steps.deploy.outputs.url || '' }}
 
 runs:
   using: "composite"


### PR DESCRIPTION
# Why

- To streamline the deployment process for Cloud Run by removing unnecessary outputs for pull request deployments.

# What

- Removed the `pr_url` output from the action configuration, which was specific to pull request deployments.
- This change simplifies the outputs of the deployment action, focusing on essential information only.