### PR TITLE
ci: add release-please for automated releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,16 @@
+name: release-please
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,4 +13,4 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,11 @@
+{
+  "action-required-reminder": "1.17.0",
+  "cleanup-cloudrun-traffic-tag": "1.17.0",
+  "deploy-cloudrun": "1.17.0",
+  "deploy-python-app-to-cloud-run": "1.17.0",
+  "monthly-project-summary-slack": "1.17.0",
+  "pr-description-writer": "1.17.0",
+  "set-image-tag": "1.17.0",
+  "setup-poetry": "1.17.0",
+  ".github/workflows": "1.17.0"
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,40 @@
+{
+  "packages": {
+    "action-required-reminder": {
+      "release-type": "simple",
+      "component": "action-required-reminder"
+    },
+    "cleanup-cloudrun-traffic-tag": {
+      "release-type": "simple",
+      "component": "cleanup-cloudrun-traffic-tag"
+    },
+    "deploy-cloudrun": {
+      "release-type": "simple",
+      "component": "deploy-cloudrun"
+    },
+    "deploy-python-app-to-cloud-run": {
+      "release-type": "simple",
+      "component": "deploy-python-app-to-cloud-run"
+    },
+    "monthly-project-summary-slack": {
+      "release-type": "simple",
+      "component": "monthly-project-summary-slack"
+    },
+    "pr-description-writer": {
+      "release-type": "node",
+      "component": "pr-description-writer"
+    },
+    "set-image-tag": {
+      "release-type": "simple",
+      "component": "set-image-tag"
+    },
+    "setup-poetry": {
+      "release-type": "simple",
+      "component": "setup-poetry"
+    },
+    ".github/workflows": {
+      "release-type": "simple",
+      "component": "reusable-workflows"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- release-please-action v4をモノレポ構成で導入
- composite actions（8つ）はそれぞれ個別リリース
- reusable workflows（4つ）は`reusable-workflows`として1コンポーネントでリリース
- 全コンポーネントを現在の最新タグ `1.17.0` からスタート

## Test plan
- [ ] mainにマージ後、release-pleaseがRelease PRを正しく作成するか確認
- [ ] 各コンポーネントに対して個別のタグが作成されるか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)