### PR TITLE
ci: fix release-please with separate PRs and component tags

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,6 @@
 {
   "action-required-reminder": "1.17.0",
+  "build-and-push-to-gar": "1.17.0",
   "cleanup-cloudrun-traffic-tag": "1.17.0",
   "deploy-cloudrun": "1.17.0",
   "deploy-python-app-to-cloud-run": "1.17.0",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,16 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
   - Single test: `poetry run pytest test_pr_reviwer.py::test_function_name`
   - Lint: `pre-commit run --all-files`
 
+## PR & Commit Convention
+- PR title must follow [Conventional Commits](https://www.conventionalcommits.org/) format (release-please uses squash merge titles for changelog)
+- Format: `<type>(<scope>): <description>`
+  - `scope` should be the component name (e.g., `deploy-cloudrun`, `reusable-workflows`)
+- Types: `feat`, `fix`, `chore`, `ci`, `docs`, `refactor`, `test`, `perf`
+- Examples:
+  - `feat(deploy-cloudrun): add health check option`
+  - `fix(pr-description-writer): handle empty body`
+  - `chore(deps): update actions/checkout to v5`
+
 ## Code Style Guidelines
 - **Python**:
   - Formatting: Use ruff-format (enforced via pre-commit)

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,8 +1,14 @@
 {
+  "separate-pull-requests": true,
+  "include-component-in-tag": true,
   "packages": {
     "action-required-reminder": {
       "release-type": "simple",
       "component": "action-required-reminder"
+    },
+    "build-and-push-to-gar": {
+      "release-type": "simple",
+      "component": "build-and-push-to-gar"
     },
     "cleanup-cloudrun-traffic-tag": {
       "release-type": "simple",


### PR DESCRIPTION
## Summary
- `separate-pull-requests: true` でコンポーネントごとに個別Release PRを作成（tree作成エラー回避）
- `include-component-in-tag: true` でタグにコンポーネント名を含める（例: `deploy-cloudrun-v1.18.0`）
- `build-and-push-to-gar` コンポーネントを追加（前回漏れ）
- CLAUDE.mdにConventional Commitsルールを追加

## Test plan
- [ ] mainマージ後、各コンポーネントごとにRelease PRが作成されるか確認
- [ ] タグが `<component>-v<version>` 形式で作成されるか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)