### PR TITLE
ci(release-please): remove .github/workflows from config

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -7,6 +7,5 @@
   "monthly-project-summary-slack": "1.17.0",
   "pr-description-writer": "1.17.0",
   "set-image-tag": "1.17.0",
-  "setup-poetry": "1.17.0",
-  ".github/workflows": "1.17.0"
+  "setup-poetry": "1.17.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -37,10 +37,6 @@
     "setup-poetry": {
       "release-type": "simple",
       "component": "setup-poetry"
-    },
-    ".github/workflows": {
-      "release-type": "simple",
-      "component": "reusable-workflows"
     }
   }
 }


### PR DESCRIPTION
## Summary
- `.github/workflows` をrelease-pleaseの管理対象から除外
- Git tree APIのネストパス問題（`Error adding to tree`）を回避
- 前回の失敗で作成されたrelease-pleaseブランチをすべて削除済み

## Test plan
- [ ] mainマージ後、release-pleaseがエラーなくRelease PRを作成するか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)