### PR TITLE
fix: update terraform plan command to disable input prompt

### DIFF
--- a/.github/workflows/reusable-terraform-gcp.yml
+++ b/.github/workflows/reusable-terraform-gcp.yml
@@ -167,7 +167,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.github_token }}
         run: |
-          tfcmt -var "target:${{ inputs.project }}" plan -patch -- terraform plan -no-color -out=tfplan.binary
+          tfcmt -var "target:${{ inputs.project }}" plan -patch -- terraform plan -no-color -out=tfplan.binary -input=false
           terraform show -json tfplan.binary > tfplan.json
           if [ "${{ inputs.save_tfplan }}" = "true" ]; then
             artifact_name="tfplan-${{ github.workflow }}-${{ inputs.project }}-${{ github.run_id }}"


### PR DESCRIPTION
## why

when variable is not given, the github actions job would be stuck.

## what

Added '-input=false' option to terraform plan command.