### PR TITLE
fix(release-please): use GitHub App token so release PR triggers CI

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,4 +13,16 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      # Use a GitHub App token instead of the default GITHUB_TOKEN so that the
+      # release PR created by release-please can trigger other workflows (CI).
+      # Events triggered by GITHUB_TOKEN do not start additional workflow runs.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.GH_APP_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
+        with:
+          token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Problem

CI does not run on release PRs created by `release-please`.

This is because the workflow used the default `GITHUB_TOKEN`. By GitHub design, events triggered by `GITHUB_TOKEN` (e.g. opening a PR) do **not** trigger other workflow runs, so CI never started on the release PR.

## Fix

Generate a GitHub App token via `actions/create-github-app-token` and pass it to `release-please-action` as `token`. PRs created with an App token trigger downstream workflows (CI).

## Details

- Secret names `GH_APP_APP_ID` / `GH_APP_PRIVATE_KEY` match the existing `pinact.yml`.
- `create-github-app-token` is SHA-pinned to v3.2.0, matching `reusable-terraform-github.yml`.

## Requirements

The GitHub App must be installed on this repo with `contents: write` and `pull-requests: write` permissions (same App used by `pinact` should work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)