### PR TITLE
feat: add tfplan_filename to make the plan identify its stack

### DIFF
--- a/.github/workflows/reusable-terraform-aws.md
+++ b/.github/workflows/reusable-terraform-aws.md
@@ -33,6 +33,7 @@ jobs:
 | `identifier` | string | **true** | - | Unique identifier for concurrency control |
 | `terraform_version_file` | string | false | `".terraform-version"` | File containing Terraform version (uses 'latest' if not found) |
 | `save_tfplan` | boolean | false | `false` | Save Terraform plan as artifact |
+| `tfplan_filename` | string | false | `"tfplan.json"` | File name for the plan JSON, also its name inside the artifact (see [Plan artifact layout](#plan-artifact-layout)) |
 | `tfplan_retention_days` | number | false | `1` | Number of days to retain Terraform plan artifact |
 | `configure_git_credentials` | boolean | false | `false` | Configure git credentials for private modules using GITHUB_TOKEN |
 
@@ -41,6 +42,31 @@ jobs:
 | Name | Description |
 |------|-------------|
 | `tfplan_artifact_name` | Name of the artifact containing terraform plan JSON |
+
+## Plan artifact layout
+
+By default the artifact holds the plan as `tfplan.json`.
+
+`actions/download-artifact` extracts a **single** artifact directly into `path`
+and only nests each artifact under its own name once two or more match. So in a
+run where only one stack planned, the artifact-name directory — the only signal
+of which stack a plan came from — is gone, and consumers that key per-stack
+behaviour off the path fall back to a generic bucket without saying so.
+
+Give the file a stack-specific name so it identifies itself either way:
+
+```yaml
+with:
+  save_tfplan: true
+  tfplan_filename: my-stack.json
+```
+
+| Artifacts in the run | Extracted to |
+|---|---|
+| 1 | `<path>/my-stack.json` |
+| 2 or more | `<path>/<artifact-name>/my-stack.json` |
+
+Consumers match both with a `**` glob, e.g. `tfplans/**/my-stack.json`.
 
 ## Prerequisites
 

--- a/.github/workflows/reusable-terraform-aws.yml
+++ b/.github/workflows/reusable-terraform-aws.yml
@@ -36,6 +36,17 @@ on:
         type: boolean
         required: false
         default: false
+      tfplan_filename:
+        description: |
+          File name for the plan JSON, which is also the name it carries inside
+          the artifact. Set it to something stack-specific to keep the stack
+          identifiable: actions/download-artifact extracts a lone artifact
+          straight into `path`, dropping the artifact-name directory, so a
+          generic tfplan.json leaves consumers no way to tell which stack the
+          plan came from.
+        type: string
+        required: false
+        default: "tfplan.json"
       tfplan_retention_days:
         type: number
         required: false
@@ -164,7 +175,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.github_token }}
         run: |
           tfcmt -var "target:${{ inputs.identifier }}" plan -patch -- terraform plan -no-color -out=tfplan.binary
-          terraform show -json tfplan.binary > tfplan.json
+          terraform show -json tfplan.binary > "${{ inputs.tfplan_filename }}"
           if [ "${{ inputs.save_tfplan }}" = "true" ]; then
             artifact_name="tfplan-${{ github.workflow }}-${{ inputs.identifier }}-${{ github.run_id }}"
             echo "tfplan_artifact_name=$artifact_name" >> "$GITHUB_OUTPUT"
@@ -175,7 +186,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: tfplan-${{ github.workflow }}-${{ inputs.identifier }}-${{ github.run_id }}
-          path: ${{ inputs.working_directory }}/tfplan.json
+          path: ${{ inputs.working_directory }}/${{ inputs.tfplan_filename }}
           retention-days: ${{ inputs.tfplan_retention_days }}
 
       - name: Terraform Apply

--- a/.github/workflows/reusable-terraform-gcp.md
+++ b/.github/workflows/reusable-terraform-gcp.md
@@ -33,6 +33,7 @@ jobs:
 | `service_account_plan` | string | false | - | GCP service account email for terraform plan |
 | `service_account_apply` | string | false | - | GCP service account email for terraform apply |
 | `save_tfplan` | boolean | false | `false` | Save Terraform plan as artifact |
+| `tfplan_filename` | string | false | `"tfplan.json"` | File name for the plan JSON, also its name inside the artifact (see [Plan artifact layout](#plan-artifact-layout)) |
 | `tfplan_retention_days` | number | false | `1` | Number of days to retain Terraform plan artifact |
 | `configure_git_credentials` | boolean | false | `false` | Configure git credentials for private modules using GITHUB_TOKEN |
 
@@ -41,6 +42,31 @@ jobs:
 | Name | Description |
 |------|-------------|
 | `tfplan_artifact_name` | Name of the artifact containing terraform plan JSON |
+
+## Plan artifact layout
+
+By default the artifact holds the plan as `tfplan.json`.
+
+`actions/download-artifact` extracts a **single** artifact directly into `path`
+and only nests each artifact under its own name once two or more match. So in a
+run where only one stack planned, the artifact-name directory — the only signal
+of which stack a plan came from — is gone, and consumers that key per-stack
+behaviour off the path fall back to a generic bucket without saying so.
+
+Give the file a stack-specific name so it identifies itself either way:
+
+```yaml
+with:
+  save_tfplan: true
+  tfplan_filename: my-project.json
+```
+
+| Artifacts in the run | Extracted to |
+|---|---|
+| 1 | `<path>/my-project.json` |
+| 2 or more | `<path>/<artifact-name>/my-project.json` |
+
+Consumers match both with a `**` glob, e.g. `tfplans/**/my-project.json`.
 
 ## Prerequisites
 

--- a/.github/workflows/reusable-terraform-gcp.yml
+++ b/.github/workflows/reusable-terraform-gcp.yml
@@ -36,6 +36,17 @@ on:
         type: boolean
         required: false
         default: false
+      tfplan_filename:
+        description: |
+          File name for the plan JSON, which is also the name it carries inside
+          the artifact. Set it to something stack-specific to keep the stack
+          identifiable: actions/download-artifact extracts a lone artifact
+          straight into `path`, dropping the artifact-name directory, so a
+          generic tfplan.json leaves consumers no way to tell which stack the
+          plan came from.
+        type: string
+        required: false
+        default: "tfplan.json"
       tfplan_retention_days:
         type: number
         required: false
@@ -168,7 +179,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.github_token }}
         run: |
           tfcmt -var "target:${{ inputs.project }}" plan -patch -- terraform plan -no-color -out=tfplan.binary -input=false
-          terraform show -json tfplan.binary > tfplan.json
+          terraform show -json tfplan.binary > "${{ inputs.tfplan_filename }}"
           if [ "${{ inputs.save_tfplan }}" = "true" ]; then
             artifact_name="tfplan-${{ github.workflow }}-${{ inputs.project }}-${{ github.run_id }}"
             echo "tfplan_artifact_name=$artifact_name" >> "$GITHUB_OUTPUT"
@@ -179,7 +190,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: tfplan-${{ github.workflow }}-${{ inputs.project }}-${{ github.run_id }}
-          path: ${{ inputs.working_directory }}/tfplan.json
+          path: ${{ inputs.working_directory }}/${{ inputs.tfplan_filename }}
           retention-days: ${{ inputs.tfplan_retention_days }}
 
       - name: Terraform Apply

--- a/.github/workflows/reusable-terraform-github.md
+++ b/.github/workflows/reusable-terraform-github.md
@@ -36,6 +36,7 @@ jobs:
 | `service_account_apply` | string | false | - | GCP service account email for terraform apply (GCS backend) |
 | `terraform_version_file` | string | false | `".terraform-version"` | File containing Terraform version (uses 'latest' if not found) |
 | `save_tfplan` | boolean | false | `false` | Save Terraform plan as artifact |
+| `tfplan_filename` | string | false | `"tfplan.json"` | File name for the plan JSON, also its name inside the artifact (see [Plan artifact layout](#plan-artifact-layout)) |
 | `tfplan_retention_days` | number | false | `1` | Number of days to retain Terraform plan artifact |
 | `configure_git_credentials` | boolean | false | `false` | Configure git credentials for private modules using GITHUB_TOKEN |
 
@@ -51,6 +52,31 @@ jobs:
 | Name | Description |
 |------|-------------|
 | `tfplan_artifact_name` | Name of the artifact containing terraform plan JSON |
+
+## Plan artifact layout
+
+By default the artifact holds the plan as `tfplan.json`.
+
+`actions/download-artifact` extracts a **single** artifact directly into `path`
+and only nests each artifact under its own name once two or more match. So in a
+run where only one stack planned, the artifact-name directory — the only signal
+of which stack a plan came from — is gone, and consumers that key per-stack
+behaviour off the path fall back to a generic bucket without saying so.
+
+Give the file a stack-specific name so it identifies itself either way:
+
+```yaml
+with:
+  save_tfplan: true
+  tfplan_filename: my-project.json
+```
+
+| Artifacts in the run | Extracted to |
+|---|---|
+| 1 | `<path>/my-project.json` |
+| 2 or more | `<path>/<artifact-name>/my-project.json` |
+
+Consumers match both with a `**` glob, e.g. `tfplans/**/my-project.json`.
 
 ## Prerequisites
 

--- a/.github/workflows/reusable-terraform-github.yml
+++ b/.github/workflows/reusable-terraform-github.yml
@@ -38,6 +38,17 @@ on:
         type: boolean
         required: false
         default: false
+      tfplan_filename:
+        description: |
+          File name for the plan JSON, which is also the name it carries inside
+          the artifact. Set it to something stack-specific to keep the stack
+          identifiable: actions/download-artifact extracts a lone artifact
+          straight into `path`, dropping the artifact-name directory, so a
+          generic tfplan.json leaves consumers no way to tell which stack the
+          plan came from.
+        type: string
+        required: false
+        default: "tfplan.json"
       tfplan_retention_days:
         type: number
         required: false
@@ -183,7 +194,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.github-app-token.outputs.token }} # For github provider (permissions are set for the GitHub app)
         run: |
           tfcmt -var "target:${{ inputs.project }}" plan -patch -- terraform plan -no-color -out=tfplan.binary
-          terraform show -json tfplan.binary > tfplan.json
+          terraform show -json tfplan.binary > "${{ inputs.tfplan_filename }}"
           if [ "${{ inputs.save_tfplan }}" = "true" ]; then
             artifact_name="tfplan-${{ github.workflow }}-${{ inputs.project }}-${{ github.run_id }}"
             echo "tfplan_artifact_name=$artifact_name" >> "$GITHUB_OUTPUT"
@@ -194,7 +205,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: tfplan-${{ github.workflow }}-${{ inputs.project }}-${{ github.run_id }}
-          path: ${{ inputs.working_directory }}/tfplan.json
+          path: ${{ inputs.working_directory }}/${{ inputs.tfplan_filename }}
           retention-days: ${{ inputs.tfplan_retention_days }}
 
       - name: Terraform Apply


### PR DESCRIPTION
## Problem

`actions/download-artifact` decides where to extract from the number of artifacts in the run:

```ts
path: isSingleArtifactDownload || inputs.mergeMultiple || artifacts.length === 1
  ? resolvedPath
  : path.join(resolvedPath, artifact.name)
```

A workflow that downloads all plans with `pattern:` therefore gets `tfplans/<artifact-name>/tfplan.json` only while two or more stacks planned. With exactly one, the plan lands flat at `tfplans/tfplan.json` and the artifact-name directory — the only signal of which stack the plan came from — is gone.

In a monorepo a PR usually touches one stack, so this is the common case rather than an edge case. Consumers that bind per-stack behaviour to that path degrade silently:

- conftest loses the target name and reports the plan under a placeholder
- tf-pr-approver's `tfplan_rule_map` cannot match a name, so the plan falls through to the `default` bucket and the stack's own rules never fire

Neither failure is visible in the logs: a stack whose plan was misfiled looks exactly like a stack that was never planned.

## Change

New input `tfplan_filename`, defaulting to `tfplan.json` — today's name, so existing callers are unaffected.

```yaml
with:
  save_tfplan: true
  tfplan_filename: my-project.json
```

The plan is written under that name and uploaded as-is, so the name travels into the artifact and the stack stays identifiable either way it is extracted:

| Artifacts in the run | Extracted to |
|---|---|
| 1 | `<path>/my-project.json` |
| 2 or more | `<path>/<artifact-name>/my-project.json` |

Consumers match both with `tfplans/**/my-project.json`. Verified against `@actions/glob`: `**` matches zero directories as well as many, so one pattern covers both layouts. (Brace expansion — `tfplans/{,*/}my-project.json` — does not work; `@actions/glob` does not expand braces.)

`upload-artifact` derives the artifact's internal structure from `path`, taking the least common ancestor of the given paths as the root, so a single file always lands at the artifact root under its basename. That is why naming the file is sufficient and `path` stays a single-file reference.

The artifact name is unchanged. Applied to all three reusable workflows (gcp, github, aws), with the layout documented in each `.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)